### PR TITLE
fix: disabled the "Normal mode" action in the "View" menu after startup

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -74,6 +74,7 @@ MainWindow::MainWindow(ConfigManager *cfManager, QWidget *parent)
     this->addToolBar(Qt::LeftToolBarArea, ToolBar);
 
     normalMode(1);
+    actionNormalmode->setDisabled(1);
 
     /** TODO: TabBar->setMovable(true);
         If move, index will change. So I must adjust `tabData`.

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -74,7 +74,6 @@ MainWindow::MainWindow(ConfigManager *cfManager, QWidget *parent)
     this->addToolBar(Qt::LeftToolBarArea, ToolBar);
 
     normalMode(1);
-    actionNormalmode->setDisabled(1);
 
     /** TODO: TabBar->setMovable(true);
         If move, index will change. So I must adjust `tabData`.

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -500,6 +500,7 @@ void MainWindow::normalMode(bool isFirst)
         ToolBar->addAction(actionAbout);
         ToolBar->addAction(actionSticky_note_mode);
         ToolBar->addAction(actionPreview_panel);
+        actionNormalmode->setDisabled(1);
     }
     actionPreferences->setEnabled(1);
     currentMode = 0;


### PR DESCRIPTION
Hi!

Comparison:

![20210401_Notepanda_comparison](https://user-images.githubusercontent.com/29089388/113241662-b82a2a00-92e1-11eb-8a15-c361ee8943e6.png)
